### PR TITLE
Add functionality to clear middlewares

### DIFF
--- a/src/RequestProcessorTrait.php
+++ b/src/RequestProcessorTrait.php
@@ -65,6 +65,27 @@ trait RequestProcessorTrait
         return $response;
     }
 
+    /** Clear the before callbacks */
+    public function clearBefore()
+    {
+        $this->before = [];
+        return $this;
+    }
+
+    /** Clear the after callbacks */
+    public function clearAfter()
+    {
+        $this->after = [];
+        return $this;
+    }
+
+    /** Clear both before and after callbacks */
+    public function clearMiddlewares()
+    {
+        $this->clearBefore()->clearAfter();
+        return $this;
+    }
+
     /**
      * Invokes callbacks from `$this->before`, and if any of them returns a
      * Response stops processing others and returns the given response.

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -312,6 +312,45 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("Exception handled", $responseText);
     }
 
+    public function testClearBeforeAfterFunctions()
+    {
+        // Arrange
+        $this->indicator = [];
+
+        $callback = $this->addIndicator('callback', 'Foo');
+
+        $app = new Application();
+        $app->get('/', $callback);
+
+        $app->before($this->addIndicator('b1'));
+        $app->before($this->addIndicator('b2'));
+
+        $app->after($this->addIndicator('a1'));
+        $app->after($this->addIndicator('a2'));
+
+        $app->finish($this->addIndicator('f1'));
+        $app->finish($this->addIndicator('f2'));
+
+        // Action
+        $app->clearMiddlewares();
+
+        $_SERVER["REQUEST_URI"] = "/";
+
+        ob_start();
+        $app->run();
+        $responseText = ob_get_clean();
+
+        // Assertion
+        $expected = [
+            'callback',
+            'f1',
+            'f2',
+        ];
+
+        $this->assertEquals($expected, $this->indicator);
+        $this->assertEquals("Foo", $responseText);
+    }
+
     public function testExceptionWithHandler()
     {
         $_SERVER["REQUEST_URI"] = "/";


### PR DESCRIPTION
this feature is implemented for testing
purpose.

In integration tests we could disable
middlewares so it's easier to test core
functionality of our app.